### PR TITLE
Replace `awk -F` based csv iteration by IFS + built-in for loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ docker run --name postgresql -itd \
 
 The above command enables the `unaccent` and `pg_trgm` modules on the databases listed in `DB_NAME`, namely `db1` and `db2`.
 
+Each comma separated field can contain whitespace, allowing you to set arbitrary options (such as `CASCADE` ). For full syntax, refer official documentation about [CREATE EXTENSION](https://www.postgresql.org/docs/current/sql-createextension.html).
+
 > **NOTE**:
 >
 > This option deprecates the `DB_UNACCENT` parameter.

--- a/runtime/functions
+++ b/runtime/functions
@@ -318,10 +318,13 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  for extension in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_EXTENSION}"); do
+  IFS_ORG=$IFS
+  IFS=,
+  for extension in ${DB_EXTENSION}; do
     echo "‣ Loading ${extension} extension..."
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS ${extension};" >/dev/null 2>&1
   done
+  IFS=$IFS_ORG
 }
 
 create_database() {
@@ -331,7 +334,9 @@ create_database() {
         echo "INFO! Database cannot be created on a $REPLICATION_MODE node. Skipping..."
         ;;
       *)
-        for database in $(awk -F',' '{for (i = 1 ; i <= NF ; i++) print $i}' <<< "${DB_NAME}"); do
+        IFS_ORG=$IFS
+        IFS=,
+        for database in ${DB_NAME}; do
           echo "Creating database: ${database}..."
           if [[ -z $(psql -U ${PG_USER} -Atc "SELECT 1 FROM pg_catalog.pg_database WHERE datname = '${database}'";) ]]; then
             psql -U ${PG_USER} -c "CREATE DATABASE \"${database}\" WITH TEMPLATE = \"${DB_TEMPLATE}\";" >/dev/null
@@ -347,6 +352,7 @@ create_database() {
             psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
           fi
         done
+        IFS=$IFS_ORG
         ;;
     esac
   fi


### PR DESCRIPTION
`awk -F,` splits values by comma but built-in for loop reinterpret each values. This behavior does not allow us to contain internal field separator (such as whitespace) in `DB_EXTENSION` and `DB_NAME`.

This PR set environment variable `IFS` (internal field separator that will affect to shell builtin functions) before / after corresponding for loop so that we can prevent unintended word splitting.

With this change, each element of `DB_EXTENSION` can include CREATE EXTENSION options.  

Example usage (note that the extension `vchord` will require additional installation process so the container exits after the line): 

```log
$ docker run --rm --env 'DB_EXTENSION=btree_gist,pg_trgm,vchord CASCADE' --env 'DB_NAME=test' --env 'DB_USER=test_user' --env 'DB_PASS=password' kkimurak/sameersbn-postgresql:16-test
Initializing datadir...
Initializing certdir...
Initializing logdir...
Initializing rundir...
Setting resolv.conf ACLs...
Initializing database...
Configuring hot standby...
‣ Setting postgresql.conf parameter: wal_level = 'hot_standby'
‣ Setting postgresql.conf parameter: max_wal_senders = '16'
‣ Setting postgresql.conf parameter: checkpoint_segments = '8'
‣ Setting postgresql.conf parameter: wal_keep_segments = '32'
‣ Setting postgresql.conf parameter: hot_standby = 'on'
‣ Setting postgresql.conf parameter: data_directory = '/var/lib/postgresql/16/main'
‣ Setting postgresql.conf parameter: log_directory = '/var/log/postgresql'
‣ Setting postgresql.conf parameter: log_filename = 'postgresql-16-main.log'
‣ Setting postgresql.conf parameter: ssl = 'off'
Creating database user: test_user
Creating database: test...
‣ Loading btree_gist extension...
‣ Loading pg_trgm extension...
‣ Loading vchord CASCADE extension...
```