### PR TITLE
Add parameter `DB_USER_IS_DB_OWNER` (boolean)

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ docker run --name postgresql -itd --restart always \
 
 In the above example `dbuser` with be granted access to both the `dbname1` and `dbname2` databases.
 
+If you want `DB_USER` to have ownership of database listed in `DB_NAME`, you can set `DB_USER_IS_DB_NAME` to true.
+
 ## Enabling extensions
 
 The image also packages the [postgres contrib module](http://www.postgresql.org/docs/9.4/static/contrib.html). A comma separated list of modules can be specified using the `DB_EXTENSION` parameter.

--- a/runtime/functions
+++ b/runtime/functions
@@ -340,11 +340,17 @@ create_database() {
           load_extensions ${database}
 
           if [[ -n ${DB_USER} ]]; then
-            echo "‣ Granting access to ${DB_USER} user..."
-            psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
+            if [[ "${DB_USER_IS_DB_OWNER}" == true ]]; then
+              echo "‣ Setting ${DB_USER} as an owner of database ${database}..."
+              psql -U ${PG_USER} -c "ALTER DATABASE ${database} OWNER TO ${DB_USER};" >/dev/null
+              # now DB_USER have access to table / schema where the owner is pg_database_owner (e.g. 'public' schema)
+            else
+              echo "‣ Granting access to ${DB_USER} user..."
+              psql -U ${PG_USER} -c "GRANT ALL PRIVILEGES ON DATABASE \"${database}\" to \"${DB_USER}\";" >/dev/null
 
-            echo "‣ Granting access on public schema to user '${DB_USER}'"
-            psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
+              echo "‣ Granting access on public schema to user '${DB_USER}'"
+              psql -U ${PG_USER} -c "GRANT ALL ON SCHEMA public TO \"${DB_USER}\";" -d "${database}" >/dev/null
+            fi
           fi
         done
         ;;


### PR DESCRIPTION
This PR add configuration parameter `DB_USER_IS_DB_OWNER` (true/false). If it is set to true, a query like the following will be issued to change the database owner after database creation : `ALTER DATABASE db_name OWNER TO ${DB_USER}`.