### PR TITLE
Fix IFS parsing

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -318,13 +318,14 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  IFS_ORG=$IFS
+  
+  IFS_ORG2=$IFS
   IFS=,
   for extension in ${DB_EXTENSION}; do
     echo "‣ Loading ${extension} extension..."
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS ${extension};" >/dev/null 2>&1
   done
-  IFS=$IFS_ORG
+  IFS=$IFS_ORG2
 }
 
 create_database() {

--- a/runtime/functions
+++ b/runtime/functions
@@ -318,7 +318,6 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  
   IFS_ORG2=$IFS
   IFS=,
   for extension in ${DB_EXTENSION}; do

--- a/runtime/functions
+++ b/runtime/functions
@@ -318,13 +318,13 @@ load_extensions() {
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS unaccent;" >/dev/null 2>&1
   fi
 
-  IFS_ORG2=$IFS
+  local IFS_ORG=$IFS
   IFS=,
   for extension in ${DB_EXTENSION}; do
     echo "‣ Loading ${extension} extension..."
     psql -U ${PG_USER} -d ${database} -c "CREATE EXTENSION IF NOT EXISTS ${extension};" >/dev/null 2>&1
   done
-  IFS=$IFS_ORG2
+  IFS=$IFS_ORG
 }
 
 create_database() {
@@ -334,7 +334,7 @@ create_database() {
         echo "INFO! Database cannot be created on a $REPLICATION_MODE node. Skipping..."
         ;;
       *)
-        IFS_ORG=$IFS
+        local IFS_ORG=$IFS
         IFS=,
         for database in ${DB_NAME}; do
           echo "Creating database: ${database}..."


### PR DESCRIPTION
Due to the function being called from create_database, the IFS is already set to , If we then update IFS_ORG to IFS, we lose the original IFS globally.
Found this while trying to add max_connection variable to our postgres as command.

This is a dirty fix, should be improved properly, as its not reusable really (sorry, its midnight here, took two hours to find the reason :D).