### PR TITLE
Add unified access to param in `postgresql.conf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ In the document, please replace ${VERSION} with the image tag.
     - [Command-line arguments](#command-line-arguments)
     - [Logs](#logs)
     - [UID/GID mapping](#uidgid-mapping)
+    - [Setting custom postgresql.conf parameter](#setting-custom-postgresqlconf-parameter)
 - [Maintenance](#maintenance)
     - [Upgrading](#upgrading)
     - [Shell Access](#shell-access)
@@ -347,6 +348,12 @@ docker run --name postgresql -itd --restart always \
   --env 'USERMAP_UID=999' --env 'USERMAP_GID=999' \
   kkimurak/sameersbn-postgresql:${VERSION}
 ```
+
+## Setting custom postgresql.conf parameter
+
+If you want to set custom parameter to postgresql.conf, you can set environment variable prefixed with `PG_PARAM_`.  
+For example, setting environment variable `PG_PARAM_EXAMPLE_PARAM=example_value` will set `example_param = example_value` in `postgresql.conf`.  
+Please note that it may conflict to existing parameter such as `PG_SSL` (`ssl` in postgresql.conf, which is also set by setting `PG_PARAM_SSL`).
 
 ## Maintenance
 

--- a/runtime/functions
+++ b/runtime/functions
@@ -76,6 +76,28 @@ set_postgresql_param() {
   fi
 }
 
+set_postgresql_param_from_env_var() {
+  local verbosity=${1:-verbose}
+  env | grep -e "^PG_PARAM_" | while read -r line; do
+    # here we can get set of environment parameter and its value like:
+    # PG_PARAM_KEY_NAME=value
+
+    # get param name : left side of =
+    param_name=${line%=*}
+    echo "‣ Extracting environment variable ${param_name}"
+    # convert PG_PARAM_KEY_NAME to key_name
+    ## remove prefix PG_PARAM_
+    key=${param_name/PG_PARAM_/}
+    ## make lowercase
+    key=${key,,}
+
+    # get value : right side of =
+    value=${line#*=}
+
+    set_postgresql_param "${key}" "${value}" "${verbosity}"
+  done
+}
+
 set_recovery_param() {
   local key=${1}
   local value=${2}
@@ -404,4 +426,6 @@ configure_postgresql() {
 
   # listen on all interfaces
   set_postgresql_param "listen_addresses" "*" quiet
+
+  set_postgresql_param_from_env_var verbose
 }


### PR DESCRIPTION
This PR adds feature to set value for parameter in `postgresql.conf` from prefixed environment variables.  
When the container starts, it parses environment variables prefixed with `PG_PARAM_` and sets postgresql.conf parameters in a specific way. This is executed just before the server starts, so it may overwrite all other environment variables or variables set by processing in functions. Users are responsible for managing environment variables when starting containers.

Possible drawback: If an environment exists where an someone can set environment variables for a container that the user does not intend, the postgresql.conf value may be set to something the user does not intend. I do not know if such situation or an environment (hosting service, etc.) exists, though.