### PR TITLE
12 or later: Replace deprecated `recovery.conf` by `standby.signal`

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -6,7 +6,7 @@ source ${PG_APP_HOME}/env-defaults
 PG_CONF=${PG_DATADIR}/postgresql.conf
 PG_HBA_CONF=${PG_DATADIR}/pg_hba.conf
 PG_IDENT_CONF=${PG_DATADIR}/pg_ident.conf
-PG_RECOVERY_CONF=${PG_DATADIR}/recovery.conf
+PG_STANDBY_SIGNAL=${PG_DATADIR}/standby.signal
 
 ## Execute command as PG_USER
 exec_as_postgres() {
@@ -96,22 +96,6 @@ set_postgresql_param_from_env_var() {
 
     set_postgresql_param "${key}" "${value}" "${verbosity}"
   done
-}
-
-set_recovery_param() {
-  local key=${1}
-  local value=${2}
-  local hide=${3}
-  if [[ -n ${value} ]]; then
-    local current=$(exec_as_postgres sed -n -e "s/^\(.*\)\(${key}=\)\([^ ']*\)\(.*\)$/\3/p" ${PG_RECOVERY_CONF})
-    if [[ "${current}" != "${value}" ]]; then
-      case ${hide} in
-        true)  echo "‣ Setting primary_conninfo parameter: ${key}" ;;
-        *) echo "‣ Setting primary_conninfo parameter: ${key} = '${value}'" ;;
-      esac
-      exec_as_postgres sed -i "s|${key}=[^ ']*|${key}=${value}|" ${PG_RECOVERY_CONF}
-    fi
-  fi
 }
 
 set_hba_param() {
@@ -288,22 +272,14 @@ set_resolvconf_perms() {
 configure_recovery() {
   if [[ ${REPLICATION_MODE} == slave ]]; then
     echo "Configuring recovery..."
-    if [[ ! -f ${PG_RECOVERY_CONF} ]]; then
-      # initialize recovery.conf on the firstrun (slave only)
-      exec_as_postgres touch ${PG_RECOVERY_CONF}
-      ( echo "standby_mode = 'on'";
-        echo "primary_conninfo = 'host=${REPLICATION_HOST} port=${REPLICATION_PORT} user=${REPLICATION_USER} password=${REPLICATION_PASS} sslmode=${REPLICATION_SSLMODE}'";
-      ) > ${PG_RECOVERY_CONF}
-    else
-      set_recovery_param "host"      "${REPLICATION_HOST}"
-      set_recovery_param "port"      "${REPLICATION_PORT}"
-      set_recovery_param "user"      "${REPLICATION_USER}"
-      set_recovery_param "password"  "${REPLICATION_PASS}"    "true"
-      set_recovery_param "sslmode"   "${REPLICATION_SSLMODE}"
+    if [[ ! -f ${PG_STANDBY_SIGNAL} ]]; then
+      # initialize standby.signal on the firstrun (slave only)
+      exec_as_postgres touch "${PG_STANDBY_SIGNAL}"
     fi
+    set_postgresql_param "primary_conninfo" "host=${REPLICATION_HOST} port=${REPLICATION_PORT} user=${REPLICATION_USER} password=${REPLICATION_PASS} sslmode=${REPLICATION_SSLMODE}" "false"
   else
-    # recovery.conf can only exist on a slave node, its existence otherwise causes problems
-    rm -rf ${PG_RECOVERY_CONF}
+    # standby.signal can only exist on a slave node, its existence otherwise causes problems
+    rm -rf "${PG_STANDBY_SIGNAL}"
   fi
 }
 


### PR DESCRIPTION
On PostgreSQL 12 and above, replication configurations are merged into postgresql.conf. It is said that `The server will not start if a recovery.conf exists.`.  

This PR removes `recovery.conf`-related functions and replace by setting parameters in `postgresql.conf` and generating `standby.signal`.

I referenced following commit:
- commit: 432b263794943b306b024fe0330fa2a68f8cbe9d  
  author: `@R4MT1N`
  commit message: `chore: make compatible with newer PostgreSQL versions`

and official documentation:
- https://www.postgresql.org/docs/12/recovery-config.html