### PR TITLE
9.6 or later: some minor changes

### DIFF
--- a/runtime/functions
+++ b/runtime/functions
@@ -147,7 +147,6 @@ configure_hot_standby() {
       echo "Configuring hot standby..."
       set_postgresql_param "wal_level" "replica"
       set_postgresql_param "max_wal_senders" "16"
-      set_postgresql_param "checkpoint_segments" "8"
       set_postgresql_param "wal_keep_segments" "32"
       set_postgresql_param "hot_standby" "on"
       ;;

--- a/runtime/functions
+++ b/runtime/functions
@@ -145,7 +145,7 @@ configure_hot_standby() {
     slave|snapshot|backup) ;;
     *)
       echo "Configuring hot standby..."
-      set_postgresql_param "wal_level" "hot_standby"
+      set_postgresql_param "wal_level" "replica"
       set_postgresql_param "max_wal_senders" "16"
       set_postgresql_param "checkpoint_segments" "8"
       set_postgresql_param "wal_keep_segments" "32"


### PR DESCRIPTION
This PR applies some minor changes (introduced: v9.6) to postgresql.conf.

- change value for `wal_level` on hot standby from `hot_standby` to `replica` (same meaning)
- delete `checkpoint_segments_setting` on hot standby